### PR TITLE
モーダルウィンドウの表示機能実装

### DIFF
--- a/src/components/Calendar/Calendar.jsx
+++ b/src/components/Calendar/Calendar.jsx
@@ -2,12 +2,15 @@ import React, { useState } from 'react';
 import "./Calendar.css";
 import dayjs from "dayjs";
 import { createCalender } from '../../utils/calendar';
+import Modal from '../Modal/Modal';
+import ModalPortal from '../Modal/ModalPortal';
 
 const Calendar = () => {
   const days = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
 
   const [month, setMonth ] = useState(dayjs().month())
   const [year, setYear ] = useState(dayjs().year())
+  const [ modalOpen, setModalOpen ] = useState(false)
 
   const prevMonth = () => {
     setMonth(month - 1);
@@ -19,38 +22,51 @@ const Calendar = () => {
 
 
   return (
-    <div className="calendar-container">
-      {/* 月表示 */}
-      <div className='current-month'>
-        <p>{month + 1}<span>月</span></p>
-      </div>
-      {/* 曜日表示 */}
-      <div className="calendar-days">
-        {days.map((day, index) => (
-          <div key={index} className='calendar-day'>
-            <h1>{day}</h1>
-          </div>
-        ))}
-      </div>
-      {/* 日付表示 */}
-      <div className="calendar-dates">
-        {createCalender(month, year).map(({ date, currentMonth, today }, index) => (
-          <div key={index} className={today ? "calendar-today" : "calendar-date"}>
-            <h1 className={currentMonth ? "calendar-current-month" : "calendar-other-month"}>
-              {date.date()}
-            </h1>
-          </div>
-        ))}
-      </div>
-      {/* 翌月、前月移動ボタン */}
-      <div className='move-btns'>
-        <div className='prev btn'>
-          <button onClick={prevMonth}>前月</button>
+    <div className='calendar-start'>
+      <div className="calendar-container">
+        {/* 月表示 */}
+        <div className='current-month'>
+          <p>{month + 1}<span>月</span></p>
         </div>
-        <div className='next btn'>
-          <button onClick={nextMonth}>翌月</button>
+        {/* 曜日表示 */}
+        <div className="calendar-days">
+          {days.map((day, index) => (
+            <div key={index} className='calendar-day'>
+              <h1>{day}</h1>
+            </div>
+          ))}
+        </div>
+        {/* 日付表示 */}
+        <div className="calendar-dates">
+          {createCalender(month, year).map(({ date, currentMonth, today }, index) => (
+            <div 
+              key={index} 
+              className={today ? "calendar-today" : "calendar-date"}
+              onClick={ () => setModalOpen(true) }
+            >
+              <h1 className={currentMonth ? "calendar-current-month" : "calendar-other-month"}>
+                {date.date()}
+              </h1>
+            </div>
+          ))}
+        </div>
+        {/* 翌月、前月移動ボタン */}
+        <div className='move-btns'>
+          <div className='prev btn'>
+            <button onClick={prevMonth}>前月</button>
+          </div>
+          <div className='next btn'>
+            <button onClick={nextMonth}>翌月</button>
+          </div>
         </div>
       </div>
+      {/* シフト入力のためのフォームをモーダルウィンドウで表示 */}
+      {modalOpen && 
+      (
+        <ModalPortal>
+          <Modal handleCloseClick={() => setModalOpen(false)} />
+        </ModalPortal>
+      )}
     </div>
   );
 }

--- a/src/components/Modal/Modal.css
+++ b/src/components/Modal/Modal.css
@@ -1,0 +1,19 @@
+.modal {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(0, 0, 0, 0.5);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+.modal-content {
+  background: white;
+  padding: 20px;
+  border-radius: 8px;
+  max-width: 500px;
+  width: 100%;
+}

--- a/src/components/Modal/Modal.jsx
+++ b/src/components/Modal/Modal.jsx
@@ -1,0 +1,14 @@
+import "./Modal.css"
+import React from 'react'
+
+const Modal = ({ handleCloseClick }) => {
+  return (
+    <div className="modal">
+      <div className="modal-content">
+        <button onClick={handleCloseClick}>閉じる</button>
+      </div>
+    </div>
+  )
+}
+
+export default Modal;

--- a/src/components/Modal/ModalPortal.jsx
+++ b/src/components/Modal/ModalPortal.jsx
@@ -1,0 +1,8 @@
+import { createPortal } from "react-dom";
+
+const ModalPortal = ({children}) => {
+  const target = document.querySelector(".calendar-start");
+  return createPortal(children, target);
+}
+
+export default ModalPortal;


### PR DESCRIPTION
# 概要
createPortalを使用し、モーダルウィンドウの表示機能を実装しました。

### 注釈
src/components/Modal/ModalPortal.jsxの`const target = document.querySelector(".calendar-start");`としていますが、後々フッター、ヘッダーを作成した場合、body要素にするかもしれません。
